### PR TITLE
Updated for Acacia and Dark Oak

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -254,6 +254,23 @@ realistic_biomes:
    max_soil_layers: 0
    biomes:
     hot_rainy: 1.0
+	
+  ACACIA:
+   inherit: tree
+   biomes:
+    hot_dry: 2.0
+    PLAINS: 1.0
+    mushroom: 0.0
+    freshwater: 0.0
+
+  DARK_OAK:
+   inherit: tree
+   biomes:
+    SWAMPLAND: 2.0
+    forest: 1.0
+    cold_forest: 0.5
+    mushroom: 0.0
+    freshwater: 0.0
 
   #......................
 


### PR DESCRIPTION
ACACIA at 2.0 in hot_dry, 1.0 in PLAINS

DARK_OAK 2.0 in swamp, 1.0 in forest, 0.5 in cold_forest

Both inherits from tree and overwrites defaults biomes to 0.
