### PR TITLE
Field pests

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -84,6 +84,7 @@ realistic_biomes:
    # the relative z-level at which to start looking for soil blocks, in this example the column will start
    # 2 blocks below the crop block, ie beneath both itself and the farmland block
    soil_layer_offset: 2
+   pest_probability: 0.001
 
   # wheat
   CROPS:

--- a/src/com/untamedears/realisticbiomes/GrowthConfig.java
+++ b/src/com/untamedears/realisticbiomes/GrowthConfig.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.logging.Logger;
 
 import org.bukkit.Material;
@@ -43,6 +44,8 @@ public class GrowthConfig extends BaseConfig {
 	private double soilBonusPerLevel;
 	// the z levels below the actual growth event location in which to start looking for the correct soil
 	private int soilLayerOffset;
+	
+	private double pestProbability;
 
 	// conversion used for persistence calculations
 	private static final int SEC_PER_HOUR = 60 * 60;
@@ -97,6 +100,8 @@ public class GrowthConfig extends BaseConfig {
 		soilMaxLayers = 0;
 		soilBonusPerLevel = 0.0;
 		soilLayerOffset = 1;
+		
+		pestProbability = 0.0;
 	}
 	
 	// make a copy of the given configuration
@@ -153,6 +158,9 @@ public class GrowthConfig extends BaseConfig {
 		
 		if (config.isSet("soil_layer_offset"))
 			soilLayerOffset = config.getInt("soil_layer_offset");
+		
+		if (config.isSet("pest_probability"))
+			pestProbability = config.getDouble("pest_probability");
 		
 		if (config.isSet("biomes"))
 			loadBiomes(config.getConfigurationSection("biomes"), biomeAliases);
@@ -272,5 +280,10 @@ public class GrowthConfig extends BaseConfig {
 		rate *= (1.0 + soilBonus);
 		
 		return rate;
+	}
+	
+	public boolean testPest() {
+		Random gen = new Random();
+		return gen.nextDouble() < pestProbability;
 	}
 }

--- a/src/com/untamedears/realisticbiomes/RealisticBiomes.java
+++ b/src/com/untamedears/realisticbiomes/RealisticBiomes.java
@@ -20,6 +20,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import com.untamedears.realisticbiomes.listener.FieldPestListener;
 import com.untamedears.realisticbiomes.listener.GrowListener;
 import com.untamedears.realisticbiomes.listener.PlayerListener;
 import com.untamedears.realisticbiomes.listener.SpawnListener;
@@ -344,6 +345,7 @@ public class RealisticBiomes extends JavaPlugin implements Listener {
 			pm.registerEvents(new GrowListener(this, materialGrowth), this);
 			pm.registerEvents(new SpawnListener(materialGrowth, fishDrops), this);
 			pm.registerEvents(new PlayerListener(this, materialGrowth), this);
+			pm.registerEvents(new FieldPestListener(this, materialGrowth), this);
 		}
 		catch(Exception e)
 		{

--- a/src/com/untamedears/realisticbiomes/listener/FieldPestListener.java
+++ b/src/com/untamedears/realisticbiomes/listener/FieldPestListener.java
@@ -1,0 +1,46 @@
+package com.untamedears.realisticbiomes.listener;
+
+import java.util.Map;
+
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Silverfish;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.potion.PotionEffectType;
+
+import com.untamedears.realisticbiomes.GrowthConfig;
+import com.untamedears.realisticbiomes.RealisticBiomes;
+
+public class FieldPestListener implements Listener {
+	private RealisticBiomes plugin;
+	private Map<Object, GrowthConfig> growthConfigs;
+	
+	public FieldPestListener(RealisticBiomes plugin, Map<Object, GrowthConfig> growthConfigs) {
+		this.plugin = plugin;
+		this.growthConfigs = growthConfigs;
+	}
+	
+	@EventHandler
+	public void onBlockBreak(BlockBreakEvent event) {
+		// right click on a growing crop with a stick: get information about that crop
+		Block block = event.getBlock();
+		Material material = block.getType();
+		
+		GrowthConfig growthConfig = growthConfigs.get(material);
+		if (growthConfig != null && growthConfig.testPest()) {
+			// Spawn a relatively harmless field pest
+			
+			Silverfish pest = (Silverfish) event.getBlock().getWorld().spawnEntity(block.getLocation(), EntityType.SILVERFISH);
+			pest.setHealth(1.0);
+			pest.addPotionEffect(PotionEffectType.SLOW.createEffect(20 * 60 * 15, 1));
+			pest.addPotionEffect(PotionEffectType.WEAKNESS.createEffect(20 * 60 * 15, 1));
+			if (event.getPlayer() != null) {
+				pest.setTarget(event.getPlayer());
+			}
+		}
+	}
+}


### PR DESCRIPTION
Add some pests to fields to make harvesting a little more chaotic. On breaking any RB-controlled crops, a probability can be set (based on the type of crop) for it to spawn a field pest - a seriously weakened silverfish. If a player broke the block, it spawns targeting them. This pull sets the chance at 1/1000 by default.

This is intended to make bulk-farming harder to bot by introducing a tiny chance of spawning slow, weak, minimum health silverfish. A normal player can easily deal with these pests with a single punch, but a bot can only do so by breaching the rules and reacting to the pest.

Hoping the days of trivial bot farming can end...
