### PR TITLE
Tidy up finding growth configs, grow chunks on load

### DIFF
--- a/src/com/untamedears/realisticbiomes/RealisticBiomes.java
+++ b/src/com/untamedears/realisticbiomes/RealisticBiomes.java
@@ -40,6 +40,24 @@ public class RealisticBiomes extends JavaPlugin implements Listener {
 	public BlockGrower blockGrower;
 	public PersistConfig persistConfig;
 	private PlantManager plantManager;
+
+	private static HashMap<TreeType, TreeType> treeTypeMap;
+	
+	static {
+		treeTypeMap = new HashMap<TreeType, TreeType>();
+		
+		treeTypeMap.put(TreeType.BIG_TREE, TreeType.TREE);
+		treeTypeMap.put(TreeType.BIRCH, TreeType.BIRCH);
+		treeTypeMap.put(TreeType.BROWN_MUSHROOM, TreeType.BROWN_MUSHROOM);
+		treeTypeMap.put(TreeType.JUNGLE, TreeType.JUNGLE);
+		treeTypeMap.put(TreeType.JUNGLE_BUSH, TreeType.JUNGLE);
+		treeTypeMap.put(TreeType.RED_MUSHROOM, TreeType.RED_MUSHROOM);
+		treeTypeMap.put(TreeType.REDWOOD, TreeType.REDWOOD);
+		treeTypeMap.put(TreeType.SMALL_JUNGLE, TreeType.JUNGLE);
+		treeTypeMap.put(TreeType.SWAMP, TreeType.TREE);
+		treeTypeMap.put(TreeType.TALL_REDWOOD, TreeType.REDWOOD);
+		treeTypeMap.put(TreeType.TREE, TreeType.TREE);
+	}
 	
 	public void onEnable() {		
 		
@@ -341,7 +359,7 @@ public class RealisticBiomes extends JavaPlugin implements Listener {
 	private void registerEvents() {
 		try {
 			PluginManager pm = getServer().getPluginManager();
-			pm.registerEvents(new GrowListener(this, materialGrowth), this);
+			pm.registerEvents(new GrowListener(this), this);
 			pm.registerEvents(new SpawnListener(materialGrowth, fishDrops), this);
 			pm.registerEvents(new PlayerListener(this, materialGrowth), this);
 		}
@@ -349,10 +367,6 @@ public class RealisticBiomes extends JavaPlugin implements Listener {
 		{
 			LOG.severe("caught an exception while attempting to register events with the PluginManager: " + e);
 		}
-	}
-
-	public HashMap<Object, GrowthConfig> getGrowthConfigs() {
-		return materialGrowth;
 	}
 	
 	public BlockGrower getBlockGrower() {
@@ -363,7 +377,8 @@ public class RealisticBiomes extends JavaPlugin implements Listener {
 	
 	// grow the specified block, return the new growth magnitude
 	// gets called when the user hits a block manually!!
-	public double growAndPersistBlock(Block block, GrowthConfig growthConfig, boolean naturalGrowEvent) {
+	public double growAndPersistBlock(Block block, boolean naturalGrowEvent) {
+		GrowthConfig growthConfig = getGrowthConfig(block);
 		
 		RealisticBiomes.doLog(Level.FINER, "RealisticBiomes:growAndPersistBlock() called for block: " + block + " and is naturalGrowEvent? " + naturalGrowEvent);
 		if (!persistConfig.enabled)
@@ -411,5 +426,27 @@ public class RealisticBiomes extends JavaPlugin implements Listener {
 	
 	public PlantManager getPlantManager() {
 		return plantManager;
+	}
+
+	public static HashMap<TreeType, TreeType> getTreeTypes() {
+		return treeTypeMap;
+	}
+	
+	public GrowthConfig getGrowthConfig(TreeType species) {
+		return materialGrowth.get(treeTypeMap.get(species));
+	}
+	
+	public GrowthConfig getGrowthConfig(Block block) {
+		Material m = block.getType();
+		return materialGrowth.get(m);
+	}
+	
+	public boolean hasGrowthConfig(Block block) {
+		Material m = block.getType();
+		return materialGrowth.containsKey(m);
+	}
+	
+	public boolean hasGrowthConfig(TreeType species) {
+		return materialGrowth.containsKey(treeTypeMap.get(species));
 	}
 }

--- a/src/com/untamedears/realisticbiomes/listener/PlayerListener.java
+++ b/src/com/untamedears/realisticbiomes/listener/PlayerListener.java
@@ -128,7 +128,7 @@ public class PlayerListener implements Listener {
 				
 				GrowthConfig growthConfig = growthConfigs.get(material);
 				if (plugin.persistConfig.enabled && growthConfig != null && growthConfig.isPersistent()) {
-					plantGrowth = plugin.growAndPersistBlock(block, growthConfig, false);
+					plantGrowth = plugin.growAndPersistBlock(block, false);
 				}
 			}
 			else {

--- a/src/com/untamedears/realisticbiomes/persist/PlantChunk.java
+++ b/src/com/untamedears/realisticbiomes/persist/PlantChunk.java
@@ -5,6 +5,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.HashMap;
+import java.util.Set;
 import java.util.logging.Level;
 
 import org.bukkit.World;
@@ -108,6 +109,10 @@ public class PlantChunk {
 		}
 		return plants.get(coords);
 	}
+	
+	public synchronized Set<Coords> getPlantCoords() {
+		return plants.keySet();
+	}
 
 	/**
 	 * Loads the plants from the database into this PlantChunk object.
@@ -159,8 +164,7 @@ public class PlantChunk {
 
 				// if the plant does not correspond to an actual crop, don't
 				// load it
-				if (!plugin.getGrowthConfigs().containsKey(
-						world.getBlockAt(x, y, z).getType())) {
+				if (plugin.getGrowthConfig(world.getBlockAt(x, y, z)) == null) {
 					RealisticBiomes.doLog(Level.FINER, "Plantchunk.load(): plant we got from db doesn't correspond to an actual crop, not loading");
 					continue;
 				}
@@ -171,8 +175,7 @@ public class PlantChunk {
 				// RealisticBiomes.growAndPersistBlock()
 				// grow the block
 				Block block = world.getBlockAt(x, y, z);
-				GrowthConfig growthConfig = plugin.getGrowthConfigs().get(
-						block.getType());
+				GrowthConfig growthConfig = plugin.getGrowthConfig(block);
 				if (growthConfig.isPersistent()) {
 					double growthAmount = growthConfig.getRate(block)
 							* plant.setUpdateTime(System.currentTimeMillis() / 1000L);

--- a/src/com/untamedears/realisticbiomes/persist/PlantManager.java
+++ b/src/com/untamedears/realisticbiomes/persist/PlantManager.java
@@ -19,11 +19,14 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
+import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
 
 import com.avaje.ebeaninternal.server.lib.sql.DataSourceException;
+import com.untamedears.realisticbiomes.GrowthConfig;
 import com.untamedears.realisticbiomes.PersistConfig;
 import com.untamedears.realisticbiomes.RealisticBiomes;
 
@@ -507,6 +510,25 @@ public class PlantManager {
 	public boolean chunkLoaded(Coords coords) {
 		Coords chunkCoords = new Coords(coords.w, coords.x/16, 0, coords.z/16);
 		return (chunks.containsKey(chunkCoords) && chunks.get(chunkCoords).isLoaded());
+	}
+	
+	public void growChunk(Coords coords) {
+		
+		
+		if (!chunkLoaded(coords)) {
+			loadChunk(coords);
+		}
+		
+		PlantChunk chunk = chunks.get(coords);
+		if (chunk.isLoaded()) {
+			for (Coords position : chunk.getPlantCoords()) {
+				Block block = plugin.getServer().getWorld(WorldID.getMCID(position.w)).getBlockAt(position.x, position.y, position.z);
+				
+				plugin.growAndPersistBlock(block, false);
+			}
+		} else {
+			// Still loading - ignore
+		}
 	}
 	
 	public void remove(Coords coords) {


### PR DESCRIPTION
This should grow chunks on load, even if the plant data is still persistently held.

It refactors a lot of messy code - every different type of growth (hit with stick, growth events, on chunk load) has been finding the configuration to load a block in a different way. This pulls that in to a couple of methods on the main plugin class which can find the growth config for a block or tree type.

Substantial testing recommended, especially around persistence and trees.
